### PR TITLE
Badge improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Nova Queue Management for Laravel Nova 4
 
-Simple resource for Laravel Nova to manage jobs from Laravel.
+A simple management of your pending or failed jobs directly in Laravel Nova. With the ability to rerun failed jobs directly from the Nova interface.
 
-**Supports only the `database` queue driver.**
+**To use this package you need to the `database` queue driver.**
 
-> This is the successor of the now abandoned [den1n/nova-queues](https://github.com/den1n/nova-queues) package. If you are using the old package, please remove it before installing this one. You only need the new package if you are using Laravel 10 or higher as the failed jobs model was incompatible with Laravel 10.
+> This is the successor of the now abandoned [den1n/nova-queues](https://github.com/den1n/nova-queues) package. If you are using the old package, please remove it before installing this one. You definitely need this new package if you are using Laravel 10 or higher as the failed jobs model was incompatible with Laravel 10. This package also adds some new features and improvements. 
+
 ## Installation
 
 Install package with Composer.

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
 	"description": "Queues resource for Laravel Nova. Based on the abandoned package by den1n.",
 	"homepage": "https://github.com/kaiserkiwi/nova-queue-management",
 	"license": "MIT",
-	"keywords": ["kaiserkiwi", "laravel", "nova", "queues"],
+	"keywords": ["kaiserkiwi", "laravel", "nova", "queues", "jobs"],
 	"authors": [{
-			"name": "Dmitry Kadochnikov",
-			"email": "iqmass@gmail.com"
-		},
-		{
 			"name": "Marco Kaiser",
 			"email": "marco@kaiser.kiwi"
+		},
+		{
+			"name": "Dmitry Kadochnikov",
+			"email": "iqmass@gmail.com"
 		}],
 	"require": {
 		"php": "^8.0",

--- a/config/nova-queue-management.php
+++ b/config/nova-queue-management.php
@@ -56,5 +56,14 @@ return [
 	'show_count_badge' => [
 		'job' => true,
 		'failed_job' => true,
-	]
+	],
+
+	/**
+	 * Sets the number of jobs and failed jobs to show the badge in the navigation bar, when a certain threshold is reached.
+	 * 0 = Always show the badge.
+	 */
+	'count_badge_threshold' => [
+		'job' => 0,
+		'failed_job' => 0,
+	],
 ];

--- a/src/Resources/FailedJob.php
+++ b/src/Resources/FailedJob.php
@@ -63,13 +63,15 @@ class FailedJob extends Resource
 	}
 
 	/**
-	 * Show menu item with badge if enabled in config.
+	 * Show menu item with badge if enabled in config and the optional threshold is reached
 	 */
 	public function menu(Request $request)
 	{
-		return config('nova-queue-management.show_count_badge.failed_job', true)
-			? parent::menu($request)->withBadge(fn() => static::$model::count())
-			: parent::menu($request);
+		if (config('nova-queue-management.show_count_badge.failed_job', true) && static::$model::count() >= config('nova-queue-management.count_badge_threshold.failed_job', 0)) {
+			return parent::menu($request)->withBadge(fn() => static::$model::count());
+		}
+
+		return parent::menu($request);
 	}
 
 	/**

--- a/src/Resources/Job.php
+++ b/src/Resources/Job.php
@@ -65,13 +65,15 @@ class Job extends Resource
 	}
 
 	/**
-	 * Show menu item with badge if enabled in config.
+	 * Show menu item with badge if enabled in config and the optional threshold is reached
 	 */
 	public function menu(Request $request)
 	{
-		return config('nova-queue-management.show_count_badge.job', true)
-			? parent::menu($request)->withBadge(fn() => static::$model::count())
-			: parent::menu($request);
+		if (config('nova-queue-management.show_count_badge.job', true) && static::$model::count() >= config('nova-queue-management.count_badge_threshold.job', 0)) {
+			return parent::menu($request)->withBadge(fn() => static::$model::count());
+		}
+
+		return parent::menu($request);
 	}
 
 	/**


### PR DESCRIPTION
This pull request adds the option to show the badge only if a certain threshold is reached. The threshold is configurable in via the config file.

This is the part of the config one has to add to their `config/nova-queue-management.php` file to change the value.
```php
'count_badge_threshold' => [
	'job' => 0,
	'failed_job' => 0,
],
```
With `0` it's always visible. But you could change it to `1` to make it only visible if there is something to watch. Every integer is possible so if you only want to know about this when the failed jobs table has 1,000 entries, go for it. 🚀 